### PR TITLE
rollup without grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,14 @@
     "grunt-contrib-concat": "^0.3.0",
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-uglify": "^0.9.1",
-    "rollup-plugin-babel": "^2.6.1"
+    "grunt-eslint": "^19.0.0",
+    "grunt-rollup": "^0.8.0",
+    "rollup": "^0.34.10",
+    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-uglify": "^1.0.1"
   },
   "scripts": {
-    "build": "grunt"
+    "build": "grunt",
+    "es6build": "rollup -c"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,11 @@ import uglify from 'rollup-plugin-uglify';
 
 export default {
   entry: 'src/js/portal/portal.js',
+  // exports: 'named', (need to learn more about this)
   moduleName: 'AgoAssistant',
   format: 'umd',
   plugins: [
-    uglify()
+    // uglify()
   ],
   dest: 'build/portal.js',
   sourceMap: 'build/portal.js.map'

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,13 @@
+import { rollup } from 'rollup';
+import uglify from 'rollup-plugin-uglify';
+
+export default {
+  entry: 'src/js/portal/portal.js',
+  moduleName: 'AgoAssistant',
+  format: 'umd',
+  plugins: [
+    uglify()
+  ],
+  dest: 'build/portal.js',
+  sourceMap: 'build/portal.js.map'
+}

--- a/src/js/portal/portal.js
+++ b/src/js/portal/portal.js
@@ -1,6 +1,7 @@
 // define(["jquery", "portal/util"], function(jquery, util) {
 import request from "./request";
-var Portal = function(config) {
+
+export function Portal (config) {
     config = typeof config !== "undefined" ? config : {};
     this.portalUrl = config.portalUrl;
     this.username = config.username;
@@ -30,8 +31,16 @@ var Portal = function(config) {
         };
         return request.post(url, data);
     }
-};
-export { Portal as default};
+
+    return this;
+}
+
+export function portal (options) {
+    return new Portal (options);
+}
+
+export default portal;
+
 // var serialize = function(obj, prefix) {
 //     var str = [];
 //     for (var p in obj) {

--- a/src/js/portal/request.js
+++ b/src/js/portal/request.js
@@ -1,97 +1,105 @@
-var request = {
-    get: function(url, parameters) {
+import portal from "./portal";
 
-        return new Promise(function(resolve, reject) {
+function get (url, parameters) {
 
-            var xhr = new XMLHttpRequest();
-            xhr.withCredentials = portal.withCredentials;
+    return new Promise(function(resolve, reject) {
 
-            xhr.addEventListener("readystatechange", function() {
-                console.log("ok");
-                if (xhr.status == 200) {
-                    // Resolve the promise with the response text
-                    resolve(JSON.parse(xhr.responseText));
-                }
-            });
+        var xhr = new XMLHttpRequest();
+        xhr.withCredentials = portal.withCredentials;
 
-            xhr.addEventListener("error", function() {
-                console.log("error");
-                reject(Error(xhr));
-            });
-
-            xhr.open("GET", url + "?" + serialize(parameters));
-            // xhr.setRequestHeader("content-type", "application/x-www-form-urlencoded");
-
-            // xhr.onload = function() {
-            //     // This is called even on 404 etc
-            //     // so check the status
-            //     if (xhr.status == 200) {
-            //         // Resolve the promise with the response text
-            //         resolve(JSON.parse(xhr.responseText));
-            //     } else {
-            //         // Otherwise reject with the status text
-            //         // which will hopefully be a meaningful error
-            //         reject(Error(xhr));
-            //     }
-            // };
-
-            xhr.send();
-        });
-
-    },
-    post: function(url, data) {
-
-        return new Promise(function(resolve, reject) {
-
-            var xhr = new XMLHttpRequest();
-            xhr.withCredentials = portal.withCredentials;
-
-            xhr.addEventListener("readystatechange", function() {
-                console.log("ok");
-                if (xhr.status == 200) {
-                    // Resolve the promise with the response text
-                    resolve(JSON.parse(xhr.responseText));
-                }
-            });
-
-            xhr.addEventListener("error", function() {
-                console.log("error");
-                reject(Error(xhr));
-            });
-
-            xhr.open("POST", url);
-            xhr.setRequestHeader("content-type", "application/x-www-form-urlencoded");
-
-            // xhr.onload = function() {
-            //     // This is called even on 404 etc
-            //     // so check the status
-            //     if (xhr.status == 200) {
-            //         // Resolve the promise with the response text
-            //         resolve(JSON.parse(xhr.responseText));
-            //     } else {
-            //         // Otherwise reject with the status text
-            //         // which will hopefully be a meaningful error
-            //         reject(Error(xhr));
-            //     }
-            // };
-
-            xhr.send(serialize(data));
-        });
-
-    },
-    serialize: function(obj, prefix) {
-        var str = [];
-        for (var p in obj) {
-            if (obj.hasOwnProperty(p)) {
-                var k = prefix ? prefix + "[" + p + "]" : p;
-                var v = obj[p];
-                str.push(typeof v == "object" ?
-                    serialize(v, k) :
-                    encodeURIComponent(k) + "=" + encodeURIComponent(v));
+        xhr.addEventListener("readystatechange", function() {
+            // console.log("ok");
+            if (xhr.status == 200) {
+                // Resolve the promise with the response text
+                resolve(JSON.parse(xhr.responseText));
             }
-        }
-        return str.join("&");
-    }
-};
+        });
 
-export { request as default };
+        xhr.addEventListener("error", function() {
+            // console.log("error");
+            reject(Error(xhr));
+        });
+
+        xhr.open("GET", url + "?" + serialize(parameters));
+        // xhr.setRequestHeader("content-type", "application/x-www-form-urlencoded");
+
+        // xhr.onload = function() {
+        //     // This is called even on 404 etc
+        //     // so check the status
+        //     if (xhr.status == 200) {
+        //         // Resolve the promise with the response text
+        //         resolve(JSON.parse(xhr.responseText));
+        //     } else {
+        //         // Otherwise reject with the status text
+        //         // which will hopefully be a meaningful error
+        //         reject(Error(xhr));
+        //     }
+        // };
+
+        xhr.send();
+    });
+
+}
+
+function post (url, data) {
+
+    return new Promise(function(resolve, reject) {
+
+        var xhr = new XMLHttpRequest();
+        xhr.withCredentials = portal.withCredentials;
+
+        xhr.addEventListener("readystatechange", function() {
+            console.log("ok");
+            if (xhr.status == 200) {
+                // Resolve the promise with the response text
+                resolve(JSON.parse(xhr.responseText));
+            }
+        });
+
+        xhr.addEventListener("error", function() {
+            console.log("error");
+            reject(Error(xhr));
+        });
+
+        xhr.open("POST", url);
+        xhr.setRequestHeader("content-type", "application/x-www-form-urlencoded");
+
+        // xhr.onload = function() {
+        //     // This is called even on 404 etc
+        //     // so check the status
+        //     if (xhr.status == 200) {
+        //         // Resolve the promise with the response text
+        //         resolve(JSON.parse(xhr.responseText));
+        //     } else {
+        //         // Otherwise reject with the status text
+        //         // which will hopefully be a meaningful error
+        //         reject(Error(xhr));
+        //     }
+        // };
+
+        xhr.send(serialize(data));
+    });
+
+}
+
+function serialize (obj, prefix) {
+    var str = [];
+    for (var p in obj) {
+        if (obj.hasOwnProperty(p)) {
+            var k = prefix ? prefix + "[" + p + "]" : p;
+            var v = obj[p];
+            str.push(typeof v == "object" ?
+                serialize(v, k) :
+                encodeURIComponent(k) + "=" + encodeURIComponent(v));
+        }
+    }
+    return str.join("&");
+}
+
+export var Request = {
+    get: get,
+    post: post,
+    serialize: serialize
+}
+
+export default Request;


### PR DESCRIPTION
this PR is primarily a sanity check / discussion starter.

i was having a hard time understanding how `grunt-rollup` was actually being used in your gruntfile so i fell back on calling rollup directly to bundle/minify `portal.js` and its dependencies.  please confirm whether or not i understand your ultimate goal.
1. write your own code as ES6 modules
2. make sure you can import external AMD dependencies
3. concatenate, minify and resolve all source in a production build

is this right? are there any other module formats you'll need to import?

if so, hopefully this PR is a good next step.  after tweaking your `portal` and `request` modules, i was able to confirm that all the relevant code was accessible.

``` js
var test = new AgoAssistant.Portal({
  portalUrl: 'https://www.arcgis.com/'
})

test.version()
  .then(function(e) {
    console.log(e.currentVersion)
  })
```
